### PR TITLE
fix: runtime crashes and undeclared runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "scikit-learn>=1.0.0",
     "asyncio-mqtt>=0.11.0",
     "aiohttp>=3.8.0",
-    "pydantic>=1.8.0",
+    "pydantic>=2.0.0",
     "rich>=12.0.0",
     "tqdm>=4.64.0",
     "click>=8.0.0",
@@ -50,7 +50,10 @@ dependencies = [
     "faiss-cpu>=1.7.0",
     "transformers>=4.20.0",
     "torch>=1.12.0",
-    "sentence-transformers>=2.2.0"
+    "sentence-transformers>=2.2.0",
+    "PyJWT>=2.4.0",
+    "cryptography>=41.0.0",
+    "PyYAML>=6.0"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ asyncio-mqtt>=0.11.0
 aiohttp>=3.8.0
 
 # Data Validation and Serialization
-pydantic>=1.8.0
+pydantic>=2.0.0
 
 # User Interface and Progress
 rich>=12.0.0
@@ -34,6 +34,13 @@ faiss-cpu>=1.7.0
 transformers>=4.20.0
 torch>=1.12.0
 sentence-transformers>=2.2.0
+
+# Authentication and Security
+PyJWT>=2.4.0
+cryptography>=41.0.0
+
+# YAML support
+PyYAML>=6.0
 
 # Optional GPU support (uncomment for GPU installations)
 # faiss-gpu>=1.7.0

--- a/safla/mcp/handlers/core_tools.py
+++ b/safla/mcp/handlers/core_tools.py
@@ -26,7 +26,7 @@ async def validate_installation_handler(args: Dict[str, Any], context: Dict[str,
         
         return {
             "valid": validation_result["valid"],
-            "checks": validation_result["checks"],
+            "system_info": validation_result.get("system_info", {}),
             "errors": validation_result.get("errors", []),
             "warnings": validation_result.get("warnings", [])
         }
@@ -102,7 +102,7 @@ async def check_gpu_status_handler(args: Dict[str, Any], context: Dict[str, Any]
     try:
         gpu_info = check_gpu_availability()
         
-        if gpu_info["available"]:
+        if gpu_info.get("cuda_available", False):
             # Try to get detailed GPU info if available
             try:
                 import torch

--- a/safla/mcp/handlers/system.py
+++ b/safla/mcp/handlers/system.py
@@ -168,14 +168,15 @@ class SystemHandler(BaseHandler):
     async def _check_gpu_status(self) -> Dict[str, Any]:
         """Check GPU availability and status."""
         try:
-            gpu_available, gpu_info = check_gpu_availability()
-            
+            gpu_info = check_gpu_availability()
+            gpu_available = gpu_info.get("cuda_available", False)
+
             result = {
                 "gpu_available": gpu_available,
                 "gpu_info": gpu_info,
                 "timestamp": time.time()
             }
-            
+
             # Additional GPU checks if available
             if gpu_available:
                 try:


### PR DESCRIPTION
## Summary

This PR fixes five real bugs found by reading the source — no style changes, no rewrites of working code.

### Runtime crash bugs (3)

**1. `safla/mcp/handlers/system.py` — TypeError: tuple-unpack of a dict**

`check_gpu_availability()` in `safla/utils/validation.py` returns a plain `Dict[str, Any]`. `SystemHandler._check_gpu_status()` called it with tuple unpacking:

```python
# before (crashes with ValueError: too many values to unpack)
gpu_available, gpu_info = check_gpu_availability()
```

```python
# after
gpu_info = check_gpu_availability()
gpu_available = gpu_info.get("cuda_available", False)
```

Any request to the `check_gpu_status` MCP tool via the `SystemHandler` class raised `ValueError` at runtime.

**2. `safla/mcp/handlers/core_tools.py` — KeyError: `"available"`**

The same function returns a dict keyed as `"cuda_available"`, but `check_gpu_status_handler` accessed `gpu_info["available"]` — a key that is never populated.

```python
# before (KeyError every call when GPU is present)
if gpu_info["available"]:

# after
if gpu_info.get("cuda_available", False):
```

**3. `safla/mcp/handlers/core_tools.py` — KeyError: `"checks"`**

`validate_installation()` returns `{"valid", "errors", "warnings", "system_info"}`. The `validate_installation_handler` accessed `validation_result["checks"]` which does not exist.

```python
# before (KeyError on every call)
"checks": validation_result["checks"],

# after
"system_info": validation_result.get("system_info", {}),
```

### Undeclared runtime dependencies (3 packages, covering 2 issues)

**4. `PyJWT` and `cryptography` not in install metadata**

`safla/auth/jwt_manager.py` does `import jwt` (PyJWT) and `safla/security/encryption.py` imports from `cryptography`. Neither package appeared in `requirements.txt` or `pyproject.toml`. Installing SAFLA from PyPI and using JWT auth or encryption would fail with `ModuleNotFoundError`.

Added `PyJWT>=2.4.0` and `cryptography>=41.0.0` to both files.

**5. `PyYAML` not in install metadata**

`safla/cli_implementations.py` does `import yaml`. `PyYAML` was not declared as a dependency. Added `PyYAML>=6.0`.

**6. `pydantic` lower bound too broad**

The declared constraint was `pydantic>=1.8.0`, but the codebase calls `.model_dump()` (a Pydantic v2 API introduced in v2.0). In Pydantic v1 the equivalent is `.dict()`. A user installing with Pydantic 1.x would get `AttributeError: 'TokenPayload' object has no attribute 'model_dump'`. Tightened to `pydantic>=2.0.0`.

## Test plan

- [ ] Call `check_gpu_status` MCP tool via `SystemHandler` — should not raise `ValueError`
- [ ] Call `check_gpu_status` via `core_tools` handler — should not raise `KeyError`
- [ ] Call `validate_installation` MCP tool — should not raise `KeyError`
- [ ] `pip install safla` in a fresh venv — `import jwt` and `import cryptography` succeed without extra steps
- [ ] `python -c "from safla.auth.jwt_manager import JWTManager"` succeeds without `ModuleNotFoundError`
- [ ] `python -c "from safla.cli_implementations import *"` succeeds without `ModuleNotFoundError` for yaml

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)