### PR TITLE
fix: TypeScript connect() crash, unused import, version 0.1.4

### DIFF
--- a/integration/mcp_integration.ts
+++ b/integration/mcp_integration.ts
@@ -97,6 +97,7 @@ export class SAFLAMCPClient extends EventEmitter {
   async connect(): Promise<void> {
     return new Promise((resolve, reject) => {
       try {
+        const [command, ...args] = this.serverPath.split(' ');
         this.process = spawn(command, args, {
           stdio: ['pipe', 'pipe', 'pipe']
         });
@@ -132,7 +133,6 @@ export class SAFLAMCPClient extends EventEmitter {
             this.emit('disconnect');
           });
         }
-        });
 
         // Initialize connection
         this.sendRequest('initialize', {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "scikit-learn>=1.0.0",
     "asyncio-mqtt>=0.11.0",
     "aiohttp>=3.8.0",
-    "pydantic>=1.8.0",
+    "pydantic>=2.0.0",
     "rich>=12.0.0",
     "tqdm>=4.64.0",
     "click>=8.0.0",
@@ -50,7 +50,10 @@ dependencies = [
     "faiss-cpu>=1.7.0",
     "transformers>=4.20.0",
     "torch>=1.12.0",
-    "sentence-transformers>=2.2.0"
+    "sentence-transformers>=2.2.0",
+    "PyJWT>=2.4.0",
+    "cryptography>=41.0.0",
+    "PyYAML>=6.0"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "safla"
-version = "0.1.3"
+version = "0.1.4"
 description = "Self-Aware Feedback Loop Algorithm - A sophisticated AI/ML system implementing autonomous learning and adaptation"
 readme = "README.md"
 license = "MIT"

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ asyncio-mqtt>=0.11.0
 aiohttp>=3.8.0
 
 # Data Validation and Serialization
-pydantic>=1.8.0
+pydantic>=2.0.0
 
 # User Interface and Progress
 rich>=12.0.0
@@ -34,6 +34,13 @@ faiss-cpu>=1.7.0
 transformers>=4.20.0
 torch>=1.12.0
 sentence-transformers>=2.2.0
+
+# Authentication and Security
+PyJWT>=2.4.0
+cryptography>=41.0.0
+
+# YAML support
+PyYAML>=6.0
 
 # Optional GPU support (uncomment for GPU installations)
 # faiss-gpu>=1.7.0

--- a/safla/__init__.py
+++ b/safla/__init__.py
@@ -12,7 +12,7 @@ This package provides:
 - Delta Evaluation System for quantifying improvements
 """
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 __author__ = "SAFLA Development Team"
 __email__ = "ruv@ruv.net"
 __license__ = "MIT"

--- a/safla/cli_implementations.py
+++ b/safla/cli_implementations.py
@@ -9,7 +9,6 @@ import asyncio
 import json
 import os
 import shutil
-import subprocess
 import time
 import psutil
 import logging

--- a/safla/mcp/handlers/core_tools.py
+++ b/safla/mcp/handlers/core_tools.py
@@ -26,7 +26,7 @@ async def validate_installation_handler(args: Dict[str, Any], context: Dict[str,
         
         return {
             "valid": validation_result["valid"],
-            "checks": validation_result["checks"],
+            "system_info": validation_result.get("system_info", {}),
             "errors": validation_result.get("errors", []),
             "warnings": validation_result.get("warnings", [])
         }
@@ -102,7 +102,7 @@ async def check_gpu_status_handler(args: Dict[str, Any], context: Dict[str, Any]
     try:
         gpu_info = check_gpu_availability()
         
-        if gpu_info["available"]:
+        if gpu_info.get("cuda_available", False):
             # Try to get detailed GPU info if available
             try:
                 import torch

--- a/safla/mcp/handlers/system.py
+++ b/safla/mcp/handlers/system.py
@@ -168,14 +168,15 @@ class SystemHandler(BaseHandler):
     async def _check_gpu_status(self) -> Dict[str, Any]:
         """Check GPU availability and status."""
         try:
-            gpu_available, gpu_info = check_gpu_availability()
-            
+            gpu_info = check_gpu_availability()
+            gpu_available = gpu_info.get("cuda_available", False)
+
             result = {
                 "gpu_available": gpu_available,
                 "gpu_info": gpu_info,
                 "timestamp": time.time()
             }
-            
+
             # Additional GPU checks if available
             if gpu_available:
                 try:


### PR DESCRIPTION
## Summary

Three correctness fixes found by auditing the TypeScript/JavaScript integration layer and Python sources.

- **`integration/mcp_integration.ts` — ReferenceError + SyntaxError in `connect()`**  
  The `connect()` method called `spawn(command, args, ...)` but `command` and `args` were never declared — any call to `connect()` would throw `ReferenceError: command is not defined` at runtime. The companion `mcp_integration.js` file had the correct line (`const [command, ...args] = this.serverPath.split(' ');`) which was lost when the TypeScript version was written. Also removed a stray `});` that would cause a `SyntaxError` before any code could run.

- **`safla/cli_implementations.py` — unused `import subprocess`**  
  The `subprocess` module is imported but never called in this file. Removing it eliminates a dead import that could mislead auditors into believing subprocess is used (relevant when reviewing for shell injection surface).

- **`pyproject.toml` + `safla/__init__.py` — version bump 0.1.3 → 0.1.4**  
  Reflect the accumulated bug fixes from this branch in the package version.

This PR is based on `fix/security-and-correctness` (PR #2) and includes all fixes from that branch plus these additional ones.

## Audit notes

- No Cargo.toml or Rust source found — the repo is Python + TypeScript, not Rust.
- No `npm audit` / `cargo audit` applicable (no `package.json` or `Cargo.toml` at root).
- No shell injection risk: all `subprocess` calls use list form (not `shell=True`).
- No hardcoded secrets found: JWT secret key is read from `JWT_SECRET_KEY` env var and raises `ValueError` if absent.
- YAML usage is output-only (`yaml.dump`), not `yaml.load` — no deserialization injection risk.
- Pickle loads are from local filesystem paths only, not from user-controlled MCP input.

## Test plan

- [ ] `node -e "require('./integration/mcp_integration.js').SAFLAMCPClient"` — no TypeError
- [ ] TypeScript compiler / tsc — no ReferenceError or SyntaxError on `mcp_integration.ts`
- [ ] `python -c "import safla; print(safla.__version__)"` → `0.1.4`
- [ ] `python -c "from safla.cli_implementations import *"` — no ImportError

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)